### PR TITLE
Prevent events from creating infinite loop

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@
       status = ac.status;
       trigger(status, hasChecked);
     }
-    if (loopMax--) {
+    if (loopMax-- > 0) {
       checkIn(1000);
     } else {
       trigger(-1, hasChecked);


### PR DESCRIPTION
If an event is fired after the loop ends with `loopMax == -1`, it will start looping forever.
